### PR TITLE
powershell does not support `cd /D`

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -557,7 +557,7 @@ function folderCpFrom(target?: any) {
                     const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
                     terminal.show();
                     const fsPath = selected[0].fsPath;
-                    if (process.platform === 'win32') {
+                    if (terminal.creationOptions.shellPath?.toLowerCase()?.includes('cmd.exe')) {
                         terminal.sendText(`cd /D ${fsPath}`);
                     } else {
                         terminal.sendText(`cd ${fsPath}`);


### PR DESCRIPTION
closes #15 

previously `cd /D` would be used always on windows, now it's only used when the terminal is `cmd.exe`